### PR TITLE
Disable the main scraper test

### DIFF
--- a/scraper/src/test/java/GroceryFamily/GroceryDad/GroceryDadTest.java
+++ b/scraper/src/test/java/GroceryFamily/GroceryDad/GroceryDadTest.java
@@ -4,6 +4,7 @@ import GroceryFamily.GroceryDad.scraper.Scraper;
 import GroceryFamily.GroceryDad.scraper.sample.TestSampleStorage;
 import GroceryFamily.GroceryDad.scraper.worker.WorkerEventListener;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 @SpringBootTest
 @ActiveProfiles("test")
+@Disabled("Relatively small bandwidth quota prevents this test from being used during an automated build")
 class GroceryDadTest {
     @Autowired
     Scraper scraper;


### PR DESCRIPTION
Unfortunately, the free bandwidth quota isn't enough to run this kind of tests during an automated build

<img width="669" alt="Screenshot 2023-08-20 at 14 03 24" src="https://github.com/GroceryFamily/BackEnd/assets/3669979/cc004f8b-dce4-42e8-9533-bdf2b4832128">